### PR TITLE
build(github-actions): split ci-php

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -1,0 +1,147 @@
+---
+
+name: lint-php
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+env:
+  SLACK_ID: ${{ secrets.SLACK_ID }}
+run-name: ${{ github.workflow }} (${{ github.ref_name }})
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    outputs:
+      done: ${{ steps.set-output.outputs.message }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - name: Cache vendor
+        id: cache-vendor
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-vendor-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Composer install
+        if: steps.cache-vendor.outputs.cache-hit != 'true'
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
+      - name: Composer dump autoload
+        run: composer dump-autoload
+      - name: PHPStan
+        run: vendor/bin/phpstan analyse --configuration phpstan.neon
+      - name: Set output
+        id: set-output
+        if: ${{ always() }}
+        run: echo "message=${{ (job.status == 'success' && ':white_check_mark:') || ':no_entry:' }} PHPStan" >> $GITHUB_OUTPUT
+  php-cs-fixer:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    outputs:
+      done: ${{ steps.set-output.outputs.message }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - name: Composer install
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
+        working-directory: tools/php-cs-fixer
+      - name: PHP CS Fixer
+        run: tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --diff
+      - name: Set output
+        id: set-output
+        if: ${{ always() }}
+        run: echo "message=${{ (job.status == 'success' && ':white_check_mark:') || ':no_entry:' }} PHP CS Fixer" >> $GITHUB_OUTPUT
+  notification-success:
+    runs-on: ubuntu-latest
+    needs: [phpstan, php-cs-fixer]
+    if: ${{ success() }}
+    steps:
+      - name: Slack notification
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": ":white_check_mark: *Success*\n\n${{ github.event.pull_request.html_url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ env.SLACK_ID }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":white_check_mark: *Success*\n\n${{ github.event.pull_request.html_url }}"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Workflow*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} (${{ github.ref_name }}) #${{ github.run_number }}>\n\n${{ needs.phpstan.outputs.done }}\n\n${{ needs.php-cs-fixer.outputs.done }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  notification-failure:
+    runs-on: ubuntu-latest
+    needs: [phpstan, php-cs-fixer]
+    if: ${{ failure() }}
+    steps:
+      - name: Slack notification
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": ":no_entry: *Failure*\n\n${{ github.event.pull_request.html_url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ env.SLACK_ID }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":no_entry: *Failure*\n\n${{ github.event.pull_request.html_url }}"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Workflow*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} (${{ github.ref_name }}) #${{ github.run_number }}>\n\n${{ needs.phpstan.outputs.done }}\n\n${{ needs.php-cs-fixer.outputs.done }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -1,6 +1,6 @@
 ---
 
-name: ci-php
+name: test-php
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -13,56 +13,6 @@ concurrency:
 permissions:
   contents: read
 jobs:
-  phpstan:
-    runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
-    outputs:
-      done: ${{ steps.set-output.outputs.message }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-      - name: Cache vendor
-        id: cache-vendor
-        uses: actions/cache@v4
-        with:
-          path: vendor
-          key: ${{ runner.os }}-vendor-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-      - name: Composer install
-        if: steps.cache-vendor.outputs.cache-hit != 'true'
-        run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
-      - name: Composer dump autoload
-        run: composer dump-autoload
-      - name: PHPStan
-        run: vendor/bin/phpstan analyse --configuration phpstan.neon
-      - name: Set output
-        id: set-output
-        if: ${{ always() }}
-        run: echo "message=${{ (job.status == 'success' && ':white_check_mark:') || ':no_entry:' }} PHPStan" >> $GITHUB_OUTPUT
-  php-cs-fixer:
-    runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
-    outputs:
-      done: ${{ steps.set-output.outputs.message }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-      - name: Composer install
-        run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
-        working-directory: tools/php-cs-fixer
-      - name: PHP CS Fixer
-        run: tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --diff
-      - name: Set output
-        id: set-output
-        if: ${{ always() }}
-        run: echo "message=${{ (job.status == 'success' && ':white_check_mark:') || ':no_entry:' }} PHP CS Fixer" >> $GITHUB_OUTPUT
   phpunit:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
@@ -95,7 +45,7 @@ jobs:
         run: echo "message=${{ (job.status == 'success' && ':white_check_mark:') || ':no_entry:' }} PHPUnit" >> $GITHUB_OUTPUT
   notification-success:
     runs-on: ubuntu-latest
-    needs: [phpstan, php-cs-fixer, phpunit]
+    needs: [phpunit]
     if: ${{ success() }}
     steps:
       - name: Slack notification
@@ -126,7 +76,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Workflow*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} (${{ github.ref_name }}) #${{ github.run_number }}>\n\n${{ needs.phpstan.outputs.done }}\n\n${{ needs.php-cs-fixer.outputs.done }}\n\n${{ needs.phpunit.outputs.done }}"
+                    "text": "*Workflow*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} (${{ github.ref_name }}) #${{ github.run_number }}>\n\n${{ needs.phpunit.outputs.done }}"
                   }
                 }
               ]
@@ -136,7 +86,7 @@ jobs:
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   notification-failure:
     runs-on: ubuntu-latest
-    needs: [phpstan, php-cs-fixer, phpunit]
+    needs: [phpunit]
     if: ${{ failure() }}
     steps:
       - name: Slack notification
@@ -167,7 +117,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Workflow*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} (${{ github.ref_name }}) #${{ github.run_number }}>\n\n${{ needs.phpstan.outputs.done }}\n\n${{ needs.php-cs-fixer.outputs.done }}\n\n${{ needs.phpunit.outputs.done }}"
+                    "text": "*Workflow*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} (${{ github.ref_name }}) #${{ github.run_number }}>\n\n${{ needs.phpunit.outputs.done }}"
                   }
                 }
               ]


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- リファクタ: GitHub Actionsのワークフロー名を `ci-php` から `lint-php` に変更しました。
- テスト: `phpunit` ジョブを削除し、新たなワークフローを追加してPHPコードのテストを行うようにしました。これには、PHPのセットアップ、依存関係のキャッシュ、PHPUnitテストの実行が含まれます。
- チョア: 成功または失敗時のSlack通知の送信機能を改善しました。具体的には、不要な `${{ needs.phpunit.outputs.done }}` を通知テキストから削除しました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->