### PR TITLE
ci(dependabot): schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,10 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: 'saturday'
+      time: '10:00'
+      timezone: 'Asia/Tokyo'
     assignees:
       - 'jnicrimi'
     reviewers:
@@ -13,7 +16,10 @@ updates:
   - package-ecosystem: 'composer'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: 'saturday'
+      time: '10:00'
+      timezone: 'Asia/Tokyo'
     assignees:
       - 'jnicrimi'
     reviewers:
@@ -21,7 +27,10 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: 'saturday'
+      time: '10:00'
+      timezone: 'Asia/Tokyo'
     assignees:
       - 'jnicrimi'
     reviewers:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: `.github/dependabot.yml`ファイルを更新しました。npm、composer、およびgithub-actionsパッケージのアップデートスケジューリング間隔を週に一度、土曜日の10:00（Asia/Tokyoタイムゾーン）に変更しました。これにより、依存関係の管理が効率化されます。
- Chore: 各パッケージのアサインとレビュワーとして'jnicrimi'を追加しました。これにより、コードレビューの負担が分散され、品質が向上します。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->