### PR TITLE
build(makefile): remove phpstan memory limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ phpunit:
 
 .PHONY: phpstan
 phpstan:
-	vendor/bin/phpstan analyse --configuration phpstan.neon --memory-limit=-1
+	vendor/bin/phpstan analyse --configuration phpstan.neon
 
 .PHONY: cs
 cs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **チョア**
  - `Makefile`の`phpstan`ターゲットコマンドからメモリ制限引数`--memory-limit=-1`を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->