### PR TITLE
refactor(github-actions): remove configuration option

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Composer dump autoload
         run: composer dump-autoload
       - name: PHPStan
-        run: vendor/bin/phpstan analyse --configuration phpstan.neon
+        run: vendor/bin/phpstan analyse
       - name: Set output
         id: set-output
         if: ${{ always() }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **チョア**
  - `phpstan analyse` コマンドから `--configuration phpstan.neon` 引数を削除して、コマンドを簡素化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->