### PR TITLE
ci(php-cs-fixer): enable no_superfluous_phpdoc_tags

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+// @phpstan-ignore-next-line
 $finder = PhpCsFixer\Finder::create()
     ->in([
         'src',
@@ -11,8 +12,10 @@ $finder = PhpCsFixer\Finder::create()
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);
 
+// @phpstan-ignore-next-line
 $config = new PhpCsFixer\Config();
 
+// @phpstan-ignore-next-line
 return $config->setRiskyAllowed(true)
     ->setRules([
         '@PSR12' => true,
@@ -63,6 +66,7 @@ return $config->setRiskyAllowed(true)
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_spaces_around_offset' => true,
+        'no_superfluous_phpdoc_tags' => true,
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_trailing_comma_in_singleline_function_call' => true,

--- a/src/HeadFirstDesignPatterns/Adapter/DuckInterface.php
+++ b/src/HeadFirstDesignPatterns/Adapter/DuckInterface.php
@@ -6,13 +6,7 @@ namespace HeadFirstDesignPatterns\Adapter;
 
 interface DuckInterface
 {
-    /**
-     * @return void
-     */
     public function quack(): void;
 
-    /**
-     * @return void
-     */
     public function fly(): void;
 }

--- a/src/HeadFirstDesignPatterns/Adapter/MallardDuck.php
+++ b/src/HeadFirstDesignPatterns/Adapter/MallardDuck.php
@@ -6,17 +6,11 @@ namespace HeadFirstDesignPatterns\Adapter;
 
 class MallardDuck implements DuckInterface
 {
-    /**
-     * @return void
-     */
     public function quack(): void
     {
         echo 'Quack'.PHP_EOL;
     }
 
-    /**
-     * @return void
-     */
     public function fly(): void
     {
         echo 'I\'m flying'.PHP_EOL;

--- a/src/HeadFirstDesignPatterns/Adapter/TurkeyAdapter.php
+++ b/src/HeadFirstDesignPatterns/Adapter/TurkeyAdapter.php
@@ -6,24 +6,15 @@ namespace HeadFirstDesignPatterns\Adapter;
 
 class TurkeyAdapter implements DuckInterface
 {
-    /**
-     * @param TurkeyInterface $turkey
-     */
     public function __construct(private readonly TurkeyInterface $turkey)
     {
     }
 
-    /**
-     * @return void
-     */
     public function quack(): void
     {
         $this->turkey->gobble();
     }
 
-    /**
-     * @return void
-     */
     public function fly(): void
     {
         for ($i = 0; $i < 5; $i++) {

--- a/src/HeadFirstDesignPatterns/Adapter/TurkeyInterface.php
+++ b/src/HeadFirstDesignPatterns/Adapter/TurkeyInterface.php
@@ -6,13 +6,7 @@ namespace HeadFirstDesignPatterns\Adapter;
 
 interface TurkeyInterface
 {
-    /**
-     * @return void
-     */
     public function gobble(): void;
 
-    /**
-     * @return void
-     */
     public function fly(): void;
 }

--- a/src/HeadFirstDesignPatterns/Adapter/WildTurkey.php
+++ b/src/HeadFirstDesignPatterns/Adapter/WildTurkey.php
@@ -6,17 +6,11 @@ namespace HeadFirstDesignPatterns\Adapter;
 
 class WildTurkey implements TurkeyInterface
 {
-    /**
-     * @return void
-     */
     public function gobble(): void
     {
         echo 'Gobble gobble'.PHP_EOL;
     }
 
-    /**
-     * @return void
-     */
     public function fly(): void
     {
         echo 'I\'m flying a short distance'.PHP_EOL;

--- a/src/HeadFirstDesignPatterns/Command/CommandInterface.php
+++ b/src/HeadFirstDesignPatterns/Command/CommandInterface.php
@@ -6,8 +6,5 @@ namespace HeadFirstDesignPatterns\Command;
 
 interface CommandInterface
 {
-    /**
-     * @return void
-     */
     public function execute(): void;
 }

--- a/src/HeadFirstDesignPatterns/Command/GarageDoor.php
+++ b/src/HeadFirstDesignPatterns/Command/GarageDoor.php
@@ -6,41 +6,26 @@ namespace HeadFirstDesignPatterns\Command;
 
 class GarageDoor
 {
-    /**
-     * @return void
-     */
     public function up(): void
     {
         echo 'Garage door is open'.PHP_EOL;
     }
 
-    /**
-     * @return void
-     */
     public function down(): void
     {
         echo 'Garage door is closed'.PHP_EOL;
     }
 
-    /**
-     * @return void
-     */
     public function stop(): void
     {
         echo 'Garage door is stopped'.PHP_EOL;
     }
 
-    /**
-     * @return void
-     */
     public function lightOn(): void
     {
         echo 'Garage light is on'.PHP_EOL;
     }
 
-    /**
-     * @return void
-     */
     public function lightOff(): void
     {
         echo 'Garage light is off'.PHP_EOL;

--- a/src/HeadFirstDesignPatterns/Command/GarageDoorOpenCommand.php
+++ b/src/HeadFirstDesignPatterns/Command/GarageDoorOpenCommand.php
@@ -6,22 +6,13 @@ namespace HeadFirstDesignPatterns\Command;
 
 class GarageDoorOpenCommand implements CommandInterface
 {
-    /**
-     * @var GarageDoor
-     */
     private GarageDoor $garageDoor;
 
-    /**
-     * @param GarageDoor $garageDoor
-     */
     public function __construct(GarageDoor $garageDoor)
     {
         $this->garageDoor = $garageDoor;
     }
 
-    /**
-     * @return void
-     */
     public function execute(): void
     {
         $this->garageDoor->up();

--- a/src/HeadFirstDesignPatterns/Command/Light.php
+++ b/src/HeadFirstDesignPatterns/Command/Light.php
@@ -6,17 +6,11 @@ namespace HeadFirstDesignPatterns\Command;
 
 class Light
 {
-    /**
-     * @return void
-     */
     public function on(): void
     {
         echo 'Light is on'.PHP_EOL;
     }
 
-    /**
-     * @return void
-     */
     public function off(): void
     {
         echo 'Light is off'.PHP_EOL;

--- a/src/HeadFirstDesignPatterns/Command/LightOffCommand.php
+++ b/src/HeadFirstDesignPatterns/Command/LightOffCommand.php
@@ -6,22 +6,13 @@ namespace HeadFirstDesignPatterns\Command;
 
 class LightOffCommand implements CommandInterface
 {
-    /**
-     * @var Light
-     */
     private Light $light;
 
-    /**
-     * @param Light $light
-     */
     public function __construct(Light $light)
     {
         $this->light = $light;
     }
 
-    /**
-     * @return void
-     */
     public function execute(): void
     {
         $this->light->off();

--- a/src/HeadFirstDesignPatterns/Command/LightOnCommand.php
+++ b/src/HeadFirstDesignPatterns/Command/LightOnCommand.php
@@ -6,22 +6,13 @@ namespace HeadFirstDesignPatterns\Command;
 
 class LightOnCommand implements CommandInterface
 {
-    /**
-     * @var Light
-     */
     private Light $light;
 
-    /**
-     * @param Light $light
-     */
     public function __construct(Light $light)
     {
         $this->light = $light;
     }
 
-    /**
-     * @return void
-     */
     public function execute(): void
     {
         $this->light->on();

--- a/src/HeadFirstDesignPatterns/Command/RemoteControl.php
+++ b/src/HeadFirstDesignPatterns/Command/RemoteControl.php
@@ -6,24 +6,13 @@ namespace HeadFirstDesignPatterns\Command;
 
 class RemoteControl
 {
-    /**
-     * @var CommandInterface
-     */
     private CommandInterface $slot;
 
-    /**
-     * @param CommandInterface $command
-     *
-     * @return void
-     */
     public function setCommand(CommandInterface $command): void
     {
         $this->slot = $command;
     }
 
-    /**
-     * @return void
-     */
     public function buttonWasPressed(): void
     {
         $this->slot->execute();

--- a/src/HeadFirstDesignPatterns/Decorator/AbstractBeverage.php
+++ b/src/HeadFirstDesignPatterns/Decorator/AbstractBeverage.php
@@ -6,21 +6,12 @@ namespace HeadFirstDesignPatterns\Decorator;
 
 abstract class AbstractBeverage
 {
-    /**
-     * @var string
-     */
     protected string $description = 'Unknown Beverage';
 
-    /**
-     * @return string
-     */
     public function getDescription(): string
     {
         return $this->description;
     }
 
-    /**
-     * @return float
-     */
     abstract public function cost(): float;
 }

--- a/src/HeadFirstDesignPatterns/Decorator/AbstractCondimentDecorator.php
+++ b/src/HeadFirstDesignPatterns/Decorator/AbstractCondimentDecorator.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Decorator;
 
 abstract class AbstractCondimentDecorator extends AbstractBeverage
 {
-    /**
-     * @param AbstractBeverage $beverage
-     */
     public function __construct(protected AbstractBeverage $beverage)
     {
     }

--- a/src/HeadFirstDesignPatterns/Decorator/DarkRoast.php
+++ b/src/HeadFirstDesignPatterns/Decorator/DarkRoast.php
@@ -11,14 +11,8 @@ class DarkRoast extends AbstractBeverage
      */
     private const COST = 0.99;
 
-    /**
-     * @var string
-     */
     protected string $description = 'Dark Roast Coffee';
 
-    /**
-     * @return float
-     */
     public function cost(): float
     {
         return self::COST;

--- a/src/HeadFirstDesignPatterns/Decorator/Espresso.php
+++ b/src/HeadFirstDesignPatterns/Decorator/Espresso.php
@@ -11,14 +11,8 @@ class Espresso extends AbstractBeverage
      */
     private const COST = 1.99;
 
-    /**
-     * @var string
-     */
     protected string $description = 'Espresso';
 
-    /**
-     * @return float
-     */
     public function cost(): float
     {
         return self::COST;

--- a/src/HeadFirstDesignPatterns/Decorator/HouseBlend.php
+++ b/src/HeadFirstDesignPatterns/Decorator/HouseBlend.php
@@ -11,14 +11,8 @@ class HouseBlend extends AbstractBeverage
      */
     private const COST = 0.89;
 
-    /**
-     * @var string
-     */
     protected string $description = 'House Blend Coffee';
 
-    /**
-     * @return float
-     */
     public function cost(): float
     {
         return self::COST;

--- a/src/HeadFirstDesignPatterns/Decorator/Mocha.php
+++ b/src/HeadFirstDesignPatterns/Decorator/Mocha.php
@@ -11,14 +11,8 @@ class Mocha extends AbstractCondimentDecorator
      */
     private const COST = 0.20;
 
-    /**
-     * @var string
-     */
     protected string $description = 'Mocha';
 
-    /**
-     * @return string
-     */
     public function getDescription(): string
     {
         return sprintf('%s, %s', $this->beverage->getDescription(), $this->description);

--- a/src/HeadFirstDesignPatterns/Decorator/Soy.php
+++ b/src/HeadFirstDesignPatterns/Decorator/Soy.php
@@ -11,22 +11,13 @@ class Soy extends AbstractCondimentDecorator
      */
     private const COST = 0.15;
 
-    /**
-     * @var string
-     */
     protected string $description = 'Soy';
 
-    /**
-     * @return string
-     */
     public function getDescription(): string
     {
         return sprintf('%s, %s', $this->beverage->getDescription(), $this->description);
     }
 
-    /**
-     * @return float
-     */
     public function cost(): float
     {
         return $this->beverage->cost() + self::COST;

--- a/src/HeadFirstDesignPatterns/Decorator/Whip.php
+++ b/src/HeadFirstDesignPatterns/Decorator/Whip.php
@@ -11,22 +11,13 @@ class Whip extends AbstractCondimentDecorator
      */
     private const COST = 0.10;
 
-    /**
-     * @var string
-     */
     protected string $description = 'Whip';
 
-    /**
-     * @return string
-     */
     public function getDescription(): string
     {
         return sprintf('%s, %s', $this->beverage->getDescription(), $this->description);
     }
 
-    /**
-     * @return float
-     */
     public function cost(): float
     {
         return $this->beverage->cost() + self::COST;

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/AbstractPizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/AbstractPizza.php
@@ -8,19 +8,10 @@ use ArrayObject;
 
 abstract class AbstractPizza
 {
-    /**
-     * @var string
-     */
     protected string $name;
 
-    /**
-     * @var DoughInterface
-     */
     protected DoughInterface $dough;
 
-    /**
-     * @var SauceInterface
-     */
     protected SauceInterface $sauce;
 
     /**
@@ -28,71 +19,39 @@ abstract class AbstractPizza
      */
     protected ArrayObject $veggies;
 
-    /**
-     * @var CheeseInterface
-     */
     protected CheeseInterface $cheese;
 
-    /**
-     * @var PepperoniInterface
-     */
     protected PepperoniInterface $pepperoni;
 
-    /**
-     * @var ClamsInterface
-     */
     protected ClamsInterface $clam;
 
-    /**
-     * @return void
-     */
     abstract public function prepare(): void;
 
-    /**
-     * @return void
-     */
     public function bake(): void
     {
         echo 'Bake for 25 minutes at 350'.PHP_EOL;
     }
 
-    /**
-     * @return void
-     */
     public function cut(): void
     {
         echo 'Cutting the pizza into diagonal slices'.PHP_EOL;
     }
 
-    /**
-     * @return void
-     */
     public function box(): void
     {
         echo 'Place pizza in official PizzaStore box'.PHP_EOL;
     }
 
-    /**
-     * @param string $name
-     *
-     * @return void
-     */
     public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         $result = '';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/AbstractPizzaStore.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/AbstractPizzaStore.php
@@ -6,18 +6,8 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 abstract class AbstractPizzaStore
 {
-    /**
-     * @param string $type
-     *
-     * @return AbstractPizza|null
-     */
     abstract protected function createPizza(string $type): ?AbstractPizza;
 
-    /**
-     * @param string $type
-     *
-     * @return AbstractPizza|null
-     */
     public function orderPizza(string $type): ?AbstractPizza
     {
         $pizza = $this->createPizza($type);

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/BlackOlives.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/BlackOlives.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class BlackOlives implements VeggiesInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Black Olives';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/CheeseInterface.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/CheeseInterface.php
@@ -6,8 +6,5 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 interface CheeseInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string;
 }

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/CheesePizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/CheesePizza.php
@@ -6,16 +6,10 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class CheesePizza extends AbstractPizza
 {
-    /**
-     * @param PizzaIngredientFactoryInterface $ingredientFactory
-     */
     public function __construct(protected PizzaIngredientFactoryInterface $ingredientFactory)
     {
     }
 
-    /**
-     * @return void
-     */
     public function prepare(): void
     {
         echo 'Preparing '.$this->name.PHP_EOL;

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ChicagoPizzaIngredientFactory.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ChicagoPizzaIngredientFactory.php
@@ -8,25 +8,16 @@ use ArrayObject;
 
 class ChicagoPizzaIngredientFactory implements PizzaIngredientFactoryInterface
 {
-    /**
-     * @return DoughInterface
-     */
     public function createDough(): DoughInterface
     {
         return new ThickCrustDough();
     }
 
-    /**
-     * @return SauceInterface
-     */
     public function createSauce(): SauceInterface
     {
         return new PlumTomatoSauce();
     }
 
-    /**
-     * @return CheeseInterface
-     */
     public function createCheese(): CheeseInterface
     {
         return new MozzarellaCheese();
@@ -45,17 +36,11 @@ class ChicagoPizzaIngredientFactory implements PizzaIngredientFactoryInterface
         return $veggies;
     }
 
-    /**
-     * @return PepperoniInterface
-     */
     public function createPepperoni(): PepperoniInterface
     {
         return new SlicedPepperoni();
     }
 
-    /**
-     * @return ClamsInterface
-     */
     public function createClam(): ClamsInterface
     {
         return new FrozenClams();

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ChicagoPizzaStore.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ChicagoPizzaStore.php
@@ -6,11 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class ChicagoPizzaStore extends AbstractPizzaStore
 {
-    /**
-     * @param string $type
-     *
-     * @return AbstractPizza|null
-     */
     protected function createPizza(string $type): ?AbstractPizza
     {
         $pizza = null;

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ClamPizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ClamPizza.php
@@ -6,16 +6,10 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class ClamPizza extends AbstractPizza
 {
-    /**
-     * @param PizzaIngredientFactoryInterface $ingredientFactory
-     */
     public function __construct(protected PizzaIngredientFactoryInterface $ingredientFactory)
     {
     }
 
-    /**
-     * @return void
-     */
     public function prepare(): void
     {
         echo 'Preparing '.$this->name.PHP_EOL;

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ClamsInterface.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ClamsInterface.php
@@ -6,8 +6,5 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 interface ClamsInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string;
 }

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/DoughInterface.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/DoughInterface.php
@@ -6,8 +6,5 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 interface DoughInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string;
 }

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/Eggplant.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/Eggplant.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class Eggplant implements VeggiesInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Eggplant';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/FreshClams.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/FreshClams.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class FreshClams implements ClamsInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Fresh Clams from Long Island Sound';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/FrozenClams.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/FrozenClams.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class FrozenClams implements ClamsInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Frozen Clams from Chesapeake Bay';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/Garlic.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/Garlic.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class Garlic implements VeggiesInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Garlic';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/MarinaraSauce.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/MarinaraSauce.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class MarinaraSauce implements SauceInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Marinara Sauce';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/MozzarellaCheese.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/MozzarellaCheese.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class MozzarellaCheese implements CheeseInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Shredded Mozzarella';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/Mushroom.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/Mushroom.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class Mushroom implements VeggiesInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Mushrooms';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/NYPizzaIngredientFactory.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/NYPizzaIngredientFactory.php
@@ -8,25 +8,16 @@ use ArrayObject;
 
 class NYPizzaIngredientFactory implements PizzaIngredientFactoryInterface
 {
-    /**
-     * @return DoughInterface
-     */
     public function createDough(): DoughInterface
     {
         return new ThinCrustDough();
     }
 
-    /**
-     * @return SauceInterface
-     */
     public function createSauce(): SauceInterface
     {
         return new MarinaraSauce();
     }
 
-    /**
-     * @return CheeseInterface
-     */
     public function createCheese(): CheeseInterface
     {
         return new ReggianoCheese();
@@ -46,17 +37,11 @@ class NYPizzaIngredientFactory implements PizzaIngredientFactoryInterface
         return $veggies;
     }
 
-    /**
-     * @return PepperoniInterface
-     */
     public function createPepperoni(): PepperoniInterface
     {
         return new SlicedPepperoni();
     }
 
-    /**
-     * @return ClamsInterface
-     */
     public function createClam(): ClamsInterface
     {
         return new FreshClams();

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/NYPizzaStore.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/NYPizzaStore.php
@@ -6,11 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class NYPizzaStore extends AbstractPizzaStore
 {
-    /**
-     * @param string $type
-     *
-     * @return AbstractPizza|null
-     */
     protected function createPizza(string $type): ?AbstractPizza
     {
         $pizza = null;

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/Onion.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/Onion.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class Onion implements VeggiesInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Onion';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ParmesanCheese.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ParmesanCheese.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class ParmesanCheese implements CheeseInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Shredded Parmesan';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/PepperoniInterface.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/PepperoniInterface.php
@@ -6,8 +6,5 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 interface PepperoniInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string;
 }

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/PepperoniPizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/PepperoniPizza.php
@@ -6,16 +6,10 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class PepperoniPizza extends AbstractPizza
 {
-    /**
-     * @param PizzaIngredientFactoryInterface $ingredientFactory
-     */
     public function __construct(protected PizzaIngredientFactoryInterface $ingredientFactory)
     {
     }
 
-    /**
-     * @return void
-     */
     public function prepare(): void
     {
         echo 'Preparing '.$this->name.PHP_EOL;

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/PizzaIngredientFactoryInterface.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/PizzaIngredientFactoryInterface.php
@@ -8,19 +8,10 @@ use ArrayObject;
 
 interface PizzaIngredientFactoryInterface
 {
-    /**
-     * @return DoughInterface
-     */
     public function createDough(): DoughInterface;
 
-    /**
-     * @return SauceInterface
-     */
     public function createSauce(): SauceInterface;
 
-    /**
-     * @return CheeseInterface
-     */
     public function createCheese(): CheeseInterface;
 
     /**
@@ -28,13 +19,7 @@ interface PizzaIngredientFactoryInterface
      */
     public function createVeggies(): ArrayObject;
 
-    /**
-     * @return PepperoniInterface
-     */
     public function createPepperoni(): PepperoniInterface;
 
-    /**
-     * @return ClamsInterface
-     */
     public function createClam(): ClamsInterface;
 }

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/PlumTomatoSauce.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/PlumTomatoSauce.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class PlumTomatoSauce implements SauceInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Tomato sauce with plum tomatoes';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/RedPepper.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/RedPepper.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class RedPepper implements VeggiesInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Red Pepper';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ReggianoCheese.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ReggianoCheese.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class ReggianoCheese implements CheeseInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Reggiano Cheese';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/SauceInterface.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/SauceInterface.php
@@ -6,8 +6,5 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 interface SauceInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string;
 }

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/SlicedPepperoni.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/SlicedPepperoni.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class SlicedPepperoni implements PepperoniInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Sliced Pepperoni';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/Spinach.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/Spinach.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class Spinach implements VeggiesInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Spinach';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ThickCrustDough.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ThickCrustDough.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class ThickCrustDough implements DoughInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'ThickCrust style extra thick crust dough';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ThinCrustDough.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/ThinCrustDough.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class ThinCrustDough implements DoughInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'Thin Crust Dough';

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/VeggiePizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/VeggiePizza.php
@@ -6,16 +6,10 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 class VeggiePizza extends AbstractPizza
 {
-    /**
-     * @param PizzaIngredientFactoryInterface $ingredientFactory
-     */
     public function __construct(protected PizzaIngredientFactoryInterface $ingredientFactory)
     {
     }
 
-    /**
-     * @return void
-     */
     public function prepare(): void
     {
         echo 'Preparing '.$this->name.PHP_EOL;

--- a/src/HeadFirstDesignPatterns/Factory/AbstractFactory/VeggiesInterface.php
+++ b/src/HeadFirstDesignPatterns/Factory/AbstractFactory/VeggiesInterface.php
@@ -6,8 +6,5 @@ namespace HeadFirstDesignPatterns\Factory\AbstractFactory;
 
 interface VeggiesInterface
 {
-    /**
-     * @return string
-     */
     public function __toString(): string;
 }

--- a/src/HeadFirstDesignPatterns/Factory/FactoryMethod/AbstractPizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/FactoryMethod/AbstractPizza.php
@@ -6,37 +6,19 @@ namespace HeadFirstDesignPatterns\Factory\FactoryMethod;
 
 abstract class AbstractPizza
 {
-    /**
-     * @var string
-     */
     protected string $name;
 
-    /**
-     * @var string
-     */
     protected string $dough;
 
-    /**
-     * @var string
-     */
     protected string $sauce;
 
-    /**
-     * @var array
-     */
     protected array $toppings = [];
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return void
-     */
     public function prepare(): void
     {
         echo 'Prepare '.$this->name.PHP_EOL;
@@ -48,33 +30,21 @@ abstract class AbstractPizza
         }
     }
 
-    /**
-     * @return void
-     */
     public function bake(): void
     {
         echo 'Bake for 25 minutes at 350';
     }
 
-    /**
-     * @return void
-     */
     public function cut(): void
     {
         echo 'Cut the pizza into diagonal slices';
     }
 
-    /**
-     * @return void
-     */
     public function box(): void
     {
         echo 'Place pizza in official PizzaStore box';
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         $display = '';

--- a/src/HeadFirstDesignPatterns/Factory/FactoryMethod/AbstractPizzaStore.php
+++ b/src/HeadFirstDesignPatterns/Factory/FactoryMethod/AbstractPizzaStore.php
@@ -6,11 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\FactoryMethod;
 
 abstract class AbstractPizzaStore
 {
-    /**
-     * @param string $type
-     *
-     * @return AbstractPizza|null
-     */
     abstract public function createPizza(string $type): ?AbstractPizza;
 
     public function orderPizza(string $type): AbstractPizza

--- a/src/HeadFirstDesignPatterns/Factory/FactoryMethod/ChicagoStyleCheesePizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/FactoryMethod/ChicagoStyleCheesePizza.php
@@ -14,9 +14,6 @@ class ChicagoStyleCheesePizza extends AbstractPizza
         $this->toppings[] = 'Shredded Mozzarella Cheese';
     }
 
-    /**
-     * @return void
-     */
     public function cut(): void
     {
         echo 'Cutting the pizza into square slices';

--- a/src/HeadFirstDesignPatterns/Factory/FactoryMethod/ChicagoStyleClamPizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/FactoryMethod/ChicagoStyleClamPizza.php
@@ -15,9 +15,6 @@ class ChicagoStyleClamPizza extends AbstractPizza
         $this->toppings[] = 'Frozen Clams from Chesapeake Bay';
     }
 
-    /**
-     * @return void
-     */
     public function cut(): void
     {
         echo 'Cutting the pizza into square slices';

--- a/src/HeadFirstDesignPatterns/Factory/FactoryMethod/ChicagoStylePepperoniPizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/FactoryMethod/ChicagoStylePepperoniPizza.php
@@ -18,9 +18,6 @@ class ChicagoStylePepperoniPizza extends AbstractPizza
         $this->toppings[] = 'Sliced Pepperoni';
     }
 
-    /**
-     * @return void
-     */
     public function cut(): void
     {
         echo 'Cutting the pizza into square slices';

--- a/src/HeadFirstDesignPatterns/Factory/FactoryMethod/ChicagoStyleVeggiePizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/FactoryMethod/ChicagoStyleVeggiePizza.php
@@ -17,9 +17,6 @@ class ChicagoStyleVeggiePizza extends AbstractPizza
         $this->toppings[] = 'Eggplant';
     }
 
-    /**
-     * @return void
-     */
     public function cut(): void
     {
         echo 'Cutting the pizza into square slices';

--- a/src/HeadFirstDesignPatterns/Factory/SimpleFactory/AbstractPizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/SimpleFactory/AbstractPizza.php
@@ -8,69 +8,39 @@ use Stringable;
 
 abstract class AbstractPizza implements Stringable
 {
-    /**
-     * @var string
-     */
     protected string $name;
 
-    /**
-     * @var string
-     */
     protected string $dough;
 
-    /**
-     * @var string
-     */
     protected string $sauce;
 
-    /**
-     * @var array
-     */
     protected array $toppings = [];
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return void
-     */
     public function prepare(): void
     {
         echo 'Preparing '.$this->name.PHP_EOL;
     }
 
-    /**
-     * @return void
-     */
     public function bake(): void
     {
         echo 'Baking '.$this->name.PHP_EOL;
     }
 
-    /**
-     * @return void
-     */
     public function cut(): void
     {
         echo 'Cutting '.$this->name.PHP_EOL;
     }
 
-    /**
-     * @return void
-     */
     public function box(): void
     {
         echo 'Boxing '.$this->name.PHP_EOL;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         $display = '';

--- a/src/HeadFirstDesignPatterns/Factory/SimpleFactory/PizzaStore.php
+++ b/src/HeadFirstDesignPatterns/Factory/SimpleFactory/PizzaStore.php
@@ -6,18 +6,10 @@ namespace HeadFirstDesignPatterns\Factory\SimpleFactory;
 
 class PizzaStore
 {
-    /**
-     * @param SimplePizzaFactory $factory
-     */
     public function __construct(private SimplePizzaFactory $factory)
     {
     }
 
-    /**
-     * @param string $type
-     *
-     * @return AbstractPizza|null
-     */
     public function orderPizza(string $type): ?AbstractPizza
     {
         $pizza = $this->factory->createPizza($type);

--- a/src/HeadFirstDesignPatterns/Factory/SimpleFactory/SimplePizzaFactory.php
+++ b/src/HeadFirstDesignPatterns/Factory/SimpleFactory/SimplePizzaFactory.php
@@ -6,11 +6,6 @@ namespace HeadFirstDesignPatterns\Factory\SimpleFactory;
 
 class SimplePizzaFactory
 {
-    /**
-     * @param string $type
-     *
-     * @return AbstractPizza|null
-     */
     public function createPizza(string $type): ?AbstractPizza
     {
         $pizza = null;

--- a/src/HeadFirstDesignPatterns/Observer/CurrentConditionsDisplay.php
+++ b/src/HeadFirstDesignPatterns/Observer/CurrentConditionsDisplay.php
@@ -6,31 +6,15 @@ namespace HeadFirstDesignPatterns\Observer;
 
 class CurrentConditionsDisplay implements DisplayElementInterface, ObserverInterface
 {
-    /**
-     * @var float
-     */
     private float $temperature;
 
-    /**
-     * @var float
-     */
     private float $humidity;
 
-    /**
-     * @param WeatherData $weatherData
-     */
     public function __construct(private WeatherData $weatherData)
     {
         $this->weatherData->registerObserver($this);
     }
 
-    /**
-     * @param float $temperature
-     * @param float $humidity
-     * @param float $pressure
-     *
-     * @return void
-     */
     public function update(float $temperature, float $humidity, float $pressure): void
     {
         $this->temperature = $temperature;
@@ -38,9 +22,6 @@ class CurrentConditionsDisplay implements DisplayElementInterface, ObserverInter
         $this->display();
     }
 
-    /**
-     * @return void
-     */
     public function display(): void
     {
         echo sprintf(

--- a/src/HeadFirstDesignPatterns/Observer/DisplayElementInterface.php
+++ b/src/HeadFirstDesignPatterns/Observer/DisplayElementInterface.php
@@ -6,8 +6,5 @@ namespace HeadFirstDesignPatterns\Observer;
 
 interface DisplayElementInterface
 {
-    /**
-     * @return void
-     */
     public function display(): void;
 }

--- a/src/HeadFirstDesignPatterns/Observer/ForecastDisplay.php
+++ b/src/HeadFirstDesignPatterns/Observer/ForecastDisplay.php
@@ -6,31 +6,15 @@ namespace HeadFirstDesignPatterns\Observer;
 
 class ForecastDisplay implements DisplayElementInterface, ObserverInterface
 {
-    /**
-     * @var float
-     */
     private float $currentPressure = 29.92;
 
-    /**
-     * @var float
-     */
     private float $lastPressure;
 
-    /**
-     * @param WeatherData $weatherData
-     */
     public function __construct(private WeatherData $weatherData)
     {
         $this->weatherData->registerObserver($this);
     }
 
-    /**
-     * @param float $temperature
-     * @param float $humidity
-     * @param float $pressure
-     *
-     * @return void
-     */
     public function update(float $temperature, float $humidity, float $pressure): void
     {
         $this->lastPressure = $this->currentPressure;
@@ -38,9 +22,6 @@ class ForecastDisplay implements DisplayElementInterface, ObserverInterface
         $this->display();
     }
 
-    /**
-     * @return void
-     */
     public function display(): void
     {
         $forecast = 'Forecast: ';

--- a/src/HeadFirstDesignPatterns/Observer/ObserverInterface.php
+++ b/src/HeadFirstDesignPatterns/Observer/ObserverInterface.php
@@ -6,12 +6,5 @@ namespace HeadFirstDesignPatterns\Observer;
 
 interface ObserverInterface
 {
-    /**
-     * @param float $temperature
-     * @param float $humidity
-     * @param float $pressure
-     *
-     * @return void
-     */
     public function update(float $temperature, float $humidity, float $pressure): void;
 }

--- a/src/HeadFirstDesignPatterns/Observer/StatisticsDisplay.php
+++ b/src/HeadFirstDesignPatterns/Observer/StatisticsDisplay.php
@@ -6,41 +6,19 @@ namespace HeadFirstDesignPatterns\Observer;
 
 class StatisticsDisplay implements DisplayElementInterface, ObserverInterface
 {
-    /**
-     * @var float
-     */
     private float $maxTemp = 0.0;
 
-    /**
-     * @var float
-     */
     private float $minTemp = 200;
 
-    /**
-     * @var float
-     */
     private float $tempSum = 0.0;
 
-    /**
-     * @var int
-     */
     private int $numReadings = 0;
 
-    /**
-     * @param WeatherData $weatherData
-     */
     public function __construct(private WeatherData $weatherData)
     {
         $this->weatherData->registerObserver($this);
     }
 
-    /**
-     * @param float $temperature
-     * @param float $humidity
-     * @param float $pressure
-     *
-     * @return void
-     */
     public function update(float $temperature, float $humidity, float $pressure): void
     {
         $this->tempSum += $temperature;
@@ -54,9 +32,6 @@ class StatisticsDisplay implements DisplayElementInterface, ObserverInterface
         $this->display();
     }
 
-    /**
-     * @return void
-     */
     public function display(): void
     {
         if ($this->numReadings === 0) {

--- a/src/HeadFirstDesignPatterns/Observer/SubjectInterface.php
+++ b/src/HeadFirstDesignPatterns/Observer/SubjectInterface.php
@@ -6,22 +6,9 @@ namespace HeadFirstDesignPatterns\Observer;
 
 interface SubjectInterface
 {
-    /**
-     * @param ObserverInterface $observer
-     *
-     * @return void
-     */
     public function registerObserver(ObserverInterface $observer): void;
 
-    /**
-     * @param ObserverInterface $observer
-     *
-     * @return void
-     */
     public function removeObserver(ObserverInterface $observer): void;
 
-    /**
-     * @return void
-     */
     public function notifyObservers(): void;
 }

--- a/src/HeadFirstDesignPatterns/Observer/WeatherData.php
+++ b/src/HeadFirstDesignPatterns/Observer/WeatherData.php
@@ -6,31 +6,14 @@ namespace HeadFirstDesignPatterns\Observer;
 
 class WeatherData implements SubjectInterface
 {
-    /**
-     * @var float
-     */
     private float $temperature;
 
-    /**
-     * @var float
-     */
     private float $humidity;
 
-    /**
-     * @var float
-     */
     private float $pressure;
 
-    /**
-     * @var array
-     */
     private array $observers = [];
 
-    /**
-     * @param ObserverInterface $observer
-     *
-     * @return void
-     */
     public function registerObserver(ObserverInterface $observer): void
     {
         if (! in_array($observer, $this->observers, true)) {
@@ -38,11 +21,6 @@ class WeatherData implements SubjectInterface
         }
     }
 
-    /**
-     * @param ObserverInterface $observer
-     *
-     * @return void
-     */
     public function removeObserver(ObserverInterface $observer): void
     {
         $key = array_search($observer, $this->observers, true);
@@ -52,9 +30,6 @@ class WeatherData implements SubjectInterface
         }
     }
 
-    /**
-     * @return void
-     */
     public function notifyObservers(): void
     {
         foreach ($this->observers as $observer) {
@@ -62,21 +37,11 @@ class WeatherData implements SubjectInterface
         }
     }
 
-    /**
-     * @return void
-     */
     public function measurementsChanged(): void
     {
         $this->notifyObservers();
     }
 
-    /**
-     * @param float $temperature
-     * @param float $humidity
-     * @param float $pressure
-     *
-     * @return void
-     */
     public function setMeasurements(float $temperature, float $humidity, float $pressure): void
     {
         $this->temperature = $temperature;
@@ -85,25 +50,16 @@ class WeatherData implements SubjectInterface
         $this->measurementsChanged();
     }
 
-    /**
-     * @return float
-     */
     public function getTemperature(): float
     {
         return $this->temperature;
     }
 
-    /**
-     * @return float
-     */
     public function getHumidity(): float
     {
         return $this->humidity;
     }
 
-    /**
-     * @return float
-     */
     public function getPressure(): float
     {
         return $this->pressure;

--- a/src/HeadFirstDesignPatterns/Singleton/Singleton.php
+++ b/src/HeadFirstDesignPatterns/Singleton/Singleton.php
@@ -6,14 +6,8 @@ namespace HeadFirstDesignPatterns\Singleton;
 
 class Singleton
 {
-    /**
-     * @var Singleton|null
-     */
     private static ?Singleton $instance = null;
 
-    /**
-     * @var string
-     */
     private string $id;
 
     private function __construct()
@@ -21,9 +15,6 @@ class Singleton
         $this->id = uniqid();
     }
 
-    /**
-     * @return Singleton
-     */
     public static function getInstance(): self
     {
         if (self::$instance === null) {
@@ -33,9 +24,6 @@ class Singleton
         return self::$instance;
     }
 
-    /**
-     * @return string
-     */
     public function getId(): string
     {
         return $this->id;

--- a/src/HeadFirstDesignPatterns/Strategy/AbstractDuck.php
+++ b/src/HeadFirstDesignPatterns/Strategy/AbstractDuck.php
@@ -6,54 +6,29 @@ namespace HeadFirstDesignPatterns\Strategy;
 
 abstract class AbstractDuck
 {
-    /**
-     * @var FlyBehaviorInterface
-     */
     protected FlyBehaviorInterface $flyBehavior;
 
-    /**
-     * @var QuackBehaviorInterface
-     */
     protected QuackBehaviorInterface $quackBehavior;
 
-    /**
-     * @param FlyBehaviorInterface $flyBehavior
-     *
-     * @return void
-     */
     public function setFlyBehavior(FlyBehaviorInterface $flyBehavior): void
     {
         $this->flyBehavior = $flyBehavior;
     }
 
-    /**
-     * @param QuackBehaviorInterface $quackBehavior
-     *
-     * @return void
-     */
     public function setQuackBehavior(QuackBehaviorInterface $quackBehavior): void
     {
         $this->quackBehavior = $quackBehavior;
     }
 
-    /**
-     * @return string
-     */
     public function fly(): string
     {
         return $this->flyBehavior->fly();
     }
 
-    /**
-     * @return string
-     */
     public function quack(): string
     {
         return $this->quackBehavior->quack();
     }
 
-    /**
-     * @return string
-     */
     abstract public function display(): string;
 }

--- a/src/HeadFirstDesignPatterns/Strategy/FlyBehaviorInterface.php
+++ b/src/HeadFirstDesignPatterns/Strategy/FlyBehaviorInterface.php
@@ -6,8 +6,5 @@ namespace HeadFirstDesignPatterns\Strategy;
 
 interface FlyBehaviorInterface
 {
-    /**
-     * @return string
-     */
     public function fly(): string;
 }

--- a/src/HeadFirstDesignPatterns/Strategy/FlyNoWay.php
+++ b/src/HeadFirstDesignPatterns/Strategy/FlyNoWay.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Strategy;
 
 class FlyNoWay implements FlyBehaviorInterface
 {
-    /**
-     * @return string
-     */
     public function fly(): string
     {
         return 'I can\'t fly';

--- a/src/HeadFirstDesignPatterns/Strategy/FlyRocketPowered.php
+++ b/src/HeadFirstDesignPatterns/Strategy/FlyRocketPowered.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Strategy;
 
 class FlyRocketPowered implements FlyBehaviorInterface
 {
-    /**
-     * @return string
-     */
     public function fly(): string
     {
         return 'I\'m flying with a rocket';

--- a/src/HeadFirstDesignPatterns/Strategy/FlyWithWings.php
+++ b/src/HeadFirstDesignPatterns/Strategy/FlyWithWings.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Strategy;
 
 class FlyWithWings implements FlyBehaviorInterface
 {
-    /**
-     * @return string
-     */
     public function fly(): string
     {
         return 'I\'m flying!!';

--- a/src/HeadFirstDesignPatterns/Strategy/MallardDuck.php
+++ b/src/HeadFirstDesignPatterns/Strategy/MallardDuck.php
@@ -12,9 +12,6 @@ class MallardDuck extends AbstractDuck
         $this->quackBehavior = new Quack();
     }
 
-    /**
-     * @return string
-     */
     public function display(): string
     {
         return 'I\'m a real Mallard duck';

--- a/src/HeadFirstDesignPatterns/Strategy/ModelDuck.php
+++ b/src/HeadFirstDesignPatterns/Strategy/ModelDuck.php
@@ -12,9 +12,6 @@ class ModelDuck extends AbstractDuck
         $this->quackBehavior = new MuteQuack();
     }
 
-    /**
-     * @return string
-     */
     public function display(): string
     {
         return 'I\'m a model duck';

--- a/src/HeadFirstDesignPatterns/Strategy/MuteQuack.php
+++ b/src/HeadFirstDesignPatterns/Strategy/MuteQuack.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Strategy;
 
 class MuteQuack implements QuackBehaviorInterface
 {
-    /**
-     * @return string
-     */
     public function quack(): string
     {
         return '<< Silence >>';

--- a/src/HeadFirstDesignPatterns/Strategy/Quack.php
+++ b/src/HeadFirstDesignPatterns/Strategy/Quack.php
@@ -6,9 +6,6 @@ namespace HeadFirstDesignPatterns\Strategy;
 
 class Quack implements QuackBehaviorInterface
 {
-    /**
-     * @return string
-     */
     public function quack(): string
     {
         return 'Quack';

--- a/src/HeadFirstDesignPatterns/Strategy/QuackBehaviorInterface.php
+++ b/src/HeadFirstDesignPatterns/Strategy/QuackBehaviorInterface.php
@@ -6,8 +6,5 @@ namespace HeadFirstDesignPatterns\Strategy;
 
 interface QuackBehaviorInterface
 {
-    /**
-     * @return string
-     */
     public function quack(): string;
 }

--- a/tests/HeadFirstDesignPatterns/Adapter/TurkeyAdapterTest.php
+++ b/tests/HeadFirstDesignPatterns/Adapter/TurkeyAdapterTest.php
@@ -11,9 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 class TurkeyAdapterTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testTurkeyToDuck(): void
     {
         $duck = new MallardDuck();

--- a/tests/HeadFirstDesignPatterns/Command/RemoteControlTest.php
+++ b/tests/HeadFirstDesignPatterns/Command/RemoteControlTest.php
@@ -13,9 +13,6 @@ use PHPUnit\Framework\TestCase;
 
 class RemoteControlTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testRemoteControl(): void
     {
         $remoteControl = new RemoteControl();

--- a/tests/HeadFirstDesignPatterns/Decorator/DarkRoastTest.php
+++ b/tests/HeadFirstDesignPatterns/Decorator/DarkRoastTest.php
@@ -11,22 +11,13 @@ use PHPUnit\Framework\TestCase;
 
 class DarkRoastTest extends TestCase
 {
-    /**
-     * @var DarkRoast
-     */
     private DarkRoast $beverage;
 
-    /**
-     * @return void
-     */
     protected function setUp(): void
     {
         $this->beverage = new DarkRoast();
     }
 
-    /**
-     * @return void
-     */
     public function testGetDescription(): void
     {
         $beverage = $this->beverage;
@@ -36,9 +27,6 @@ class DarkRoastTest extends TestCase
         $this->assertSame('Dark Roast Coffee, Mocha, Mocha, Whip', $beverage->getDescription());
     }
 
-    /**
-     * @return void
-     */
     public function testCost(): void
     {
         $beverage = $this->beverage;

--- a/tests/HeadFirstDesignPatterns/Decorator/EspressoTest.php
+++ b/tests/HeadFirstDesignPatterns/Decorator/EspressoTest.php
@@ -9,30 +9,18 @@ use PHPUnit\Framework\TestCase;
 
 class EspressoTest extends TestCase
 {
-    /**
-     * @var Espresso
-     */
     private Espresso $beverage;
 
-    /**
-     * @return void
-     */
     protected function setUp(): void
     {
         $this->beverage = new Espresso();
     }
 
-    /**
-     * @return void
-     */
     public function testGetDescription(): void
     {
         $this->assertSame('Espresso', $this->beverage->getDescription());
     }
 
-    /**
-     * @return void
-     */
     public function testCost(): void
     {
         $this->assertSame(1.99, $this->beverage->cost());

--- a/tests/HeadFirstDesignPatterns/Decorator/HouseBlendTest.php
+++ b/tests/HeadFirstDesignPatterns/Decorator/HouseBlendTest.php
@@ -12,22 +12,13 @@ use PHPUnit\Framework\TestCase;
 
 class HouseBlendTest extends TestCase
 {
-    /**
-     * @var HouseBlend
-     */
     private HouseBlend $beverage;
 
-    /**
-     * @return void
-     */
     protected function setUp(): void
     {
         $this->beverage = new HouseBlend();
     }
 
-    /**
-     * @return void
-     */
     public function testGetDescription(): void
     {
         $beverage = $this->beverage;
@@ -37,9 +28,6 @@ class HouseBlendTest extends TestCase
         $this->assertSame('House Blend Coffee, Soy, Mocha, Whip', $beverage->getDescription());
     }
 
-    /**
-     * @return void
-     */
     public function testCost(): void
     {
         $beverage = $this->beverage;

--- a/tests/HeadFirstDesignPatterns/Factory/AbstractFactory/ChicagoPizzaStoreTest.php
+++ b/tests/HeadFirstDesignPatterns/Factory/AbstractFactory/ChicagoPizzaStoreTest.php
@@ -9,14 +9,8 @@ use PHPUnit\Framework\TestCase;
 
 class ChicagoPizzaStoreTest extends TestCase
 {
-    /**
-     * @var ChicagoPizzaStore
-     */
     private ChicagoPizzaStore $store;
 
-    /**
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -25,11 +19,6 @@ class ChicagoPizzaStoreTest extends TestCase
 
     /**
      * @dataProvider provideOrderPizza
-     *
-     * @param string $type
-     * @param string $expected
-     *
-     * @return void
      */
     public function testOrderPizza(string $type, string $expected): void
     {
@@ -37,9 +26,6 @@ class ChicagoPizzaStoreTest extends TestCase
         $this->assertEquals($expected, $pizza->getName());
     }
 
-    /**
-     * @return array
-     */
     public static function provideOrderPizza(): array
     {
         return [

--- a/tests/HeadFirstDesignPatterns/Factory/AbstractFactory/NYPizzaStoreTest.php
+++ b/tests/HeadFirstDesignPatterns/Factory/AbstractFactory/NYPizzaStoreTest.php
@@ -9,14 +9,8 @@ use PHPUnit\Framework\TestCase;
 
 class NYPizzaStoreTest extends TestCase
 {
-    /**
-     * @var NYPizzaStore
-     */
     private NYPizzaStore $store;
 
-    /**
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -25,11 +19,6 @@ class NYPizzaStoreTest extends TestCase
 
     /**
      * @dataProvider provideOrderPizza
-     *
-     * @param string $type
-     * @param string $expected
-     *
-     * @return void
      */
     public function testOrderPizza(string $type, string $expected): void
     {
@@ -37,9 +26,6 @@ class NYPizzaStoreTest extends TestCase
         $this->assertEquals($expected, $pizza->getName());
     }
 
-    /**
-     * @return array
-     */
     public static function provideOrderPizza(): array
     {
         return [

--- a/tests/HeadFirstDesignPatterns/Factory/FactoryMethod/ChicagoPizzaStoreTest.php
+++ b/tests/HeadFirstDesignPatterns/Factory/FactoryMethod/ChicagoPizzaStoreTest.php
@@ -9,14 +9,8 @@ use PHPUnit\Framework\TestCase;
 
 class ChicagoPizzaStoreTest extends TestCase
 {
-    /**
-     * @var ChicagoPizzaStore
-     */
     private ChicagoPizzaStore $store;
 
-    /**
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -25,11 +19,6 @@ class ChicagoPizzaStoreTest extends TestCase
 
     /**
      * @dataProvider provideCreatePizza
-     *
-     * @param string $type
-     * @param string $expected
-     *
-     * @return void
      */
     public function testCreatePizza(string $type, string $expected): void
     {
@@ -37,9 +26,6 @@ class ChicagoPizzaStoreTest extends TestCase
         $this->assertEquals($expected, $pizza->getName());
     }
 
-    /**
-     * @return array
-     */
     public static function provideCreatePizza(): array
     {
         return [

--- a/tests/HeadFirstDesignPatterns/Factory/FactoryMethod/NYPizzaStoreTest.php
+++ b/tests/HeadFirstDesignPatterns/Factory/FactoryMethod/NYPizzaStoreTest.php
@@ -9,14 +9,8 @@ use PHPUnit\Framework\TestCase;
 
 class NYPizzaStoreTest extends TestCase
 {
-    /**
-     * @var NYPizzaStore
-     */
     private NYPizzaStore $store;
 
-    /**
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -25,11 +19,6 @@ class NYPizzaStoreTest extends TestCase
 
     /**
      * @dataProvider provideCreatePizza
-     *
-     * @param string $type
-     * @param string $expected
-     *
-     * @return void
      */
     public function testCreatePizza(string $type, string $expected): void
     {
@@ -37,9 +26,6 @@ class NYPizzaStoreTest extends TestCase
         $this->assertEquals($expected, $pizza->getName());
     }
 
-    /**
-     * @return array
-     */
     public static function provideCreatePizza(): array
     {
         return [

--- a/tests/HeadFirstDesignPatterns/Factory/SimpleFactory/PizzaStoreTest.php
+++ b/tests/HeadFirstDesignPatterns/Factory/SimpleFactory/PizzaStoreTest.php
@@ -13,9 +13,6 @@ class PizzaStoreTest extends TestCase
     /**
      * @dataProvider provideOrderPizza
      *
-     * @param string $type
-     * @param string $outputString
-     *
      * @return void
      */
     public function testOrderPizza(string $type, string $outputString)
@@ -29,9 +26,6 @@ class PizzaStoreTest extends TestCase
         $this->expectOutputString($outputString);
     }
 
-    /**
-     * @return array
-     */
     public static function provideOrderPizza(): array
     {
         $cheeseOutputString = <<<'EOF'

--- a/tests/HeadFirstDesignPatterns/Observer/WeatherDataTest.php
+++ b/tests/HeadFirstDesignPatterns/Observer/WeatherDataTest.php
@@ -12,9 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 class WeatherDataTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testSetMeasurements(): void
     {
         $weatherData = new WeatherData();

--- a/tests/HeadFirstDesignPatterns/Singleton/SingletonTest.php
+++ b/tests/HeadFirstDesignPatterns/Singleton/SingletonTest.php
@@ -9,9 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 class SingletonTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testUniqueInstance(): void
     {
         $instance1 = Singleton::getInstance();
@@ -20,9 +17,6 @@ class SingletonTest extends TestCase
         $this->assertSame($instance1, $instance2);
     }
 
-    /**
-     * @return void
-     */
     public function testId(): void
     {
         $instance1 = Singleton::getInstance();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
  - 不要なPHPDocコメントが、多くのクラスやメソッドから削除されました。コメントの削除は、コードの可読性とメンテナンス性を向上させます。
  - 型宣言やコメントの削除により、コードが簡潔になりました。

- **テスト**
  - `SingletonTest`クラスのテストメソッドからPHPDocコメントが削除され、テストコードがより簡潔になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->