### PR TITLE
refactor: simple factory, abstract class name, remove prefix

### DIFF
--- a/src/HeadFirstDesignPatterns/Factory/SimpleFactory/CheesePizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/SimpleFactory/CheesePizza.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace HeadFirstDesignPatterns\Factory\SimpleFactory;
 
-class CheesePizza extends AbstractPizza
+class CheesePizza extends Pizza
 {
     public function __construct()
     {

--- a/src/HeadFirstDesignPatterns/Factory/SimpleFactory/ClamPizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/SimpleFactory/ClamPizza.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace HeadFirstDesignPatterns\Factory\SimpleFactory;
 
-class ClamPizza extends AbstractPizza
+class ClamPizza extends Pizza
 {
     public function __construct()
     {

--- a/src/HeadFirstDesignPatterns/Factory/SimpleFactory/PepperoniPizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/SimpleFactory/PepperoniPizza.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace HeadFirstDesignPatterns\Factory\SimpleFactory;
 
-class PepperoniPizza extends AbstractPizza
+class PepperoniPizza extends Pizza
 {
     public function __construct()
     {

--- a/src/HeadFirstDesignPatterns/Factory/SimpleFactory/Pizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/SimpleFactory/Pizza.php
@@ -6,7 +6,7 @@ namespace HeadFirstDesignPatterns\Factory\SimpleFactory;
 
 use Stringable;
 
-abstract class AbstractPizza implements Stringable
+abstract class Pizza implements Stringable
 {
     protected string $name;
 

--- a/src/HeadFirstDesignPatterns/Factory/SimpleFactory/PizzaStore.php
+++ b/src/HeadFirstDesignPatterns/Factory/SimpleFactory/PizzaStore.php
@@ -10,7 +10,7 @@ class PizzaStore
     {
     }
 
-    public function orderPizza(string $type): ?AbstractPizza
+    public function orderPizza(string $type): ?Pizza
     {
         $pizza = $this->factory->createPizza($type);
         if ($pizza === null) {

--- a/src/HeadFirstDesignPatterns/Factory/SimpleFactory/SimplePizzaFactory.php
+++ b/src/HeadFirstDesignPatterns/Factory/SimpleFactory/SimplePizzaFactory.php
@@ -6,7 +6,7 @@ namespace HeadFirstDesignPatterns\Factory\SimpleFactory;
 
 class SimplePizzaFactory
 {
-    public function createPizza(string $type): ?AbstractPizza
+    public function createPizza(string $type): ?Pizza
     {
         $pizza = null;
         switch ($type) {

--- a/src/HeadFirstDesignPatterns/Factory/SimpleFactory/VeggiePizza.php
+++ b/src/HeadFirstDesignPatterns/Factory/SimpleFactory/VeggiePizza.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace HeadFirstDesignPatterns\Factory\SimpleFactory;
 
-class VeggiePizza extends AbstractPizza
+class VeggiePizza extends Pizza
 {
     public function __construct()
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ピザクラスの継承構造を更新し、`AbstractPizza`から`Pizza`へ変更しました。これにより、クラスのインタラクションが改善され、デザインパターンの簡素化が期待されます。

- **バグ修正**
	- `PizzaStore`および`SimplePizzaFactory`クラスの`orderPizza`および`createPizza`メソッドの戻り値の型を`?AbstractPizza`から`?Pizza`に変更しました。これにより、より具体的な戻り値が保証されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->