### PR TITLE
refactor: strategy, abstract class name, remove prefix

### DIFF
--- a/src/HeadFirstDesignPatterns/Strategy/Duck.php
+++ b/src/HeadFirstDesignPatterns/Strategy/Duck.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace HeadFirstDesignPatterns\Strategy;
 
-abstract class AbstractDuck
+abstract class Duck
 {
     protected FlyBehaviorInterface $flyBehavior;
 

--- a/src/HeadFirstDesignPatterns/Strategy/MallardDuck.php
+++ b/src/HeadFirstDesignPatterns/Strategy/MallardDuck.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace HeadFirstDesignPatterns\Strategy;
 
-class MallardDuck extends AbstractDuck
+class MallardDuck extends Duck
 {
     public function __construct()
     {

--- a/src/HeadFirstDesignPatterns/Strategy/ModelDuck.php
+++ b/src/HeadFirstDesignPatterns/Strategy/ModelDuck.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace HeadFirstDesignPatterns\Strategy;
 
-class ModelDuck extends AbstractDuck
+class ModelDuck extends Duck
 {
     public function __construct()
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 抽象クラスの名前を `AbstractDuck` から `Duck` に変更し、クラス名の明確さと使いやすさを向上。
  - `MallardDuck` と `ModelDuck` が `Duck` から継承されるようになり、これによりそれぞれの動作が具体的に実装される。

- **バグ修正**
  - 変更に伴うクラス参照の更新が必要になる可能性があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->